### PR TITLE
Add Next.js PWA MVP skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# codex-vs-cursor
+# GeoProspect MVP
+
+Application de prospection géolocalisée (PWA) construite avec Next.js 14.
+
+## Configuration `.env.local`
+
+```
+NEXT_PUBLIC_SUPABASE_URL=<https://xxx.supabase.co>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<clé publique Supabase>
+NEXT_PUBLIC_GOOGLE_MAPS_KEY=<clé Google Maps JS>
+```
+
+## Import CSV
+
+```
+yarn import:csv prospects.csv
+```

--- a/app/api/import-csv/route.ts
+++ b/app/api/import-csv/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { parse } from 'csv-parse/sync'
+
+export async function POST(req: NextRequest) {
+  const body = await req.text()
+  const records = parse(body, { columns: true, skip_empty_lines: true }) as any[]
+  const { error } = await supabase.from('prospects').insert(records)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 })
+  }
+  return NextResponse.json({ message: 'Import OK' })
+}

--- a/app/components/ProspectModal.tsx
+++ b/app/components/ProspectModal.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+export interface Prospect {
+  id: number
+  name: string
+  address: string
+  phone: string
+  email: string
+  latitude: number
+  longitude: number
+}
+
+export default function ProspectModal({ prospect, onClose }: { prospect: Prospect; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded w-80 space-y-2">
+        <h2 className="text-lg font-semibold">{prospect.name}</h2>
+        <p>{prospect.address}</p>
+        <p>{prospect.phone}</p>
+        <div className="flex space-x-2 mt-4">
+          <a href={`tel:${prospect.phone}`} className="flex-1 p-2 bg-green-600 text-white text-center rounded">Appeler</a>
+          <a href={`mailto:${prospect.email}`} className="flex-1 p-2 bg-blue-600 text-white text-center rounded">Email</a>
+          <a
+            href={`https://www.google.com/maps/dir/?api=1&destination=${prospect.latitude},${prospect.longitude}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 p-2 bg-gray-600 text-white text-center rounded"
+          >
+            Itinéraire
+          </a>
+        </div>
+        <button onClick={onClose} className="mt-4 w-full p-2 bg-red-600 text-white rounded">Fermer</button>
+      </div>
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/hooks/useCurrentPosition.ts
+++ b/app/hooks/useCurrentPosition.ts
@@ -1,0 +1,48 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export interface Position {
+  latitude: number
+  longitude: number
+}
+
+export function useCurrentPosition() {
+  const [position, setPosition] = useState<Position | null>(null)
+  const [consent, setConsent] = useState<'granted' | 'denied' | null>(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('geoConsent') as 'granted' | 'denied' | null
+    if (stored) {
+      setConsent(stored)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (consent === 'granted' && !position) {
+      navigator.geolocation.getCurrentPosition((pos) => {
+        setPosition({
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+        })
+      })
+    }
+  }, [consent, position])
+
+  const Banner = !consent ? (
+    <div className="fixed bottom-0 inset-x-0 bg-gray-800 text-white p-4 flex justify-between items-center">
+      <span>Nous utilisons votre position pour afficher les prospects autour de vous.</span>
+      <button
+        className="ml-4 px-3 py-1 bg-blue-600 rounded"
+        onClick={() => {
+          localStorage.setItem('geoConsent', 'granted')
+          setConsent('granted')
+        }}
+      >
+        J'accepte
+      </button>
+    </div>
+  ) : null
+
+  return { position, ConsentBanner: Banner }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,17 @@
+import './globals.css'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'GeoProspect',
+  description: 'Prospection géolocalisée',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="fr" className="dark">
+      <body className="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useRouter } from 'next/navigation'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/map')
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-xs space-y-4">
+        <h1 className="text-xl font-semibold text-center">Connexion</h1>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <input
+          className="w-full p-2 border rounded"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="w-full p-2 border rounded"
+          type="password"
+          placeholder="Mot de passe"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button className="w-full p-2 bg-blue-600 text-white rounded" type="submit">
+          Se connecter
+        </button>
+      </form>
+    </main>
+  )
+}

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import Script from 'next/script'
+import { supabase } from '@/lib/supabase'
+import { useCurrentPosition } from '@/app/hooks/useCurrentPosition'
+import ProspectModal, { Prospect } from '@/app/components/ProspectModal'
+
+const RADIUS_KM = 5
+
+export default function MapPage() {
+  const { position, ConsentBanner } = useCurrentPosition()
+  const mapRef = useRef<HTMLDivElement>(null)
+  const [map, setMap] = useState<google.maps.Map | null>(null)
+  const [prospects, setProspects] = useState<Prospect[]>([])
+  const [selected, setSelected] = useState<Prospect | null>(null)
+
+  useEffect(() => {
+    if (position && mapRef.current && !map) {
+      const mapObj = new google.maps.Map(mapRef.current, {
+        center: { lat: position.latitude, lng: position.longitude },
+        zoom: 14,
+      })
+      setMap(mapObj)
+    }
+  }, [position, map])
+
+  useEffect(() => {
+    if (!map || !position) return
+    async function loadProspects() {
+      const { data } = await supabase.rpc('prospects_within_radius', {
+        lat: position.latitude,
+        lng: position.longitude,
+        radius_km: RADIUS_KM,
+      })
+      if (data) {
+        setProspects(data)
+      }
+    }
+    loadProspects()
+  }, [map, position])
+
+  useEffect(() => {
+    if (!map) return
+    prospects.forEach((prospect) => {
+      const marker = new google.maps.Marker({
+        position: { lat: prospect.latitude, lng: prospect.longitude },
+        map,
+      })
+      marker.addListener('click', () => setSelected(prospect))
+    })
+  }, [map, prospects])
+
+  return (
+    <main className="h-screen w-full">
+      <Script src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY}`}></Script>
+      <div ref={mapRef} className="h-full" />
+      {ConsentBanner}
+      {selected && <ProspectModal prospect={selected} onClose={() => setSelected(null)} />}
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4">
+      <h1 className="text-2xl font-bold mb-4">GeoProspect</h1>
+      <Link className="text-blue-500" href="/login">Se connecter</Link>
+    </main>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+
+export const supabase = createClient(supabaseUrl, supabaseKey)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+declare module '*.svg' {
+  const content: React.FunctionComponent<React.SVGProps<SVGSVGElement>>
+  export default content
+}
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,14 @@
+const withPWA = require('next-pwa')({
+  dest: 'public',
+  register: true,
+  skipWaiting: true,
+  disable: process.env.NODE_ENV === 'development',
+  swSrc: 'public/service-worker.js'
+})
+
+module.exports = withPWA({
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "geoprospect",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "import:csv": "ts-node scripts/import-csv.ts"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
+    "csv-parse": "^5.5.0",
+    "next": "14.2.4",
+    "next-pwa": "^7.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.36",
+    "@types/node": "20.11.9",
+    "tailwindcss": "^3.4.4",
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.31",
+    "typescript": "^5.3.3",
+    "ts-node": "^10.9.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,15 @@
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
+})
+
+workbox.routing.registerRoute(
+  ({ url }) => url.href.includes('/rest/v1/prospects'),
+  new workbox.strategies.NetworkFirst({ cacheName: 'prospects' })
+)
+
+workbox.routing.registerRoute(
+  ({ url }) => url.origin.includes('googleapis.com') || url.origin.includes('gstatic.com'),
+  new workbox.strategies.StaleWhileRevalidate({ cacheName: 'map-tiles' })
+)

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { readFile } from 'fs/promises'
+
+async function main() {
+  const file = process.argv[2]
+  if (!file) {
+    console.error('Usage: import-csv <file>')
+    process.exit(1)
+  }
+  const csv = await readFile(file, 'utf8')
+  const res = await fetch('http://localhost:3000/api/import-csv', {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/csv' },
+    body: csv,
+  })
+  if (!res.ok) {
+    console.error('Import failed:', await res.text())
+    process.exit(1)
+  }
+  console.log('Import successful')
+}
+
+main()

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 app with Tailwind and PWA configuration
- implement login page using Supabase Auth
- add geolocation hook with consent banner
- create map page displaying prospects and modal details
- service worker caches prospects and map tiles
- CSV import API route and CLI script
- document environment variables and import command

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852feb5b9a8832083a4eaa86e0669b9